### PR TITLE
zizmor audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         version: [min, 1, nightly]
@@ -30,22 +32,24 @@ jobs:
             version: nightly
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Julia Setup
-        uses: julia-actions/setup-julia@v3
+        uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3
         with:
             version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
             cache-compiled: "true"
       - name: Test
-        uses: julia-actions/julia-runtest@v1
+        uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Coverage Process
-        uses: julia-actions/julia-processcoverage@v1
+        uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
       - name: Coverage Upload
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: lcov.info
         env:

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -12,16 +12,20 @@ on:
       - release-*
 jobs:
   Documenter:
-    permissions: write-all
+    permissions:
+      contents: write
+      statuses: write
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/cache@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
           cache-compiled: "true"
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      - uses: julia-actions/julia-docdeploy@e62cc8fd639797a0c2922a437d5b1b81c4a12787 # v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -7,15 +7,20 @@ jobs:
   typos-check:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Actions Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@aca895bf05aec0cb7dffa6f94495e923224d9f17 # v1.46.2
         with:
             config: _typos.toml
             write_changes: true
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         with:
           tool_name: Typos
           fail_on_error: true

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,19 +16,22 @@ jobs:
     # Run on push's or non-draft PRs
     if: (github.event_name == 'push') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
-    # TODO: further restrict this
-    permissions: write-all
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         version: [1]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Julia Setup
-        uses: julia-actions/setup-julia@v3
+        uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3
         with:
             version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
         with:
             cache-compiled: "true"
       - name: Instantiate `format` environment and format
@@ -38,7 +41,7 @@ jobs:
           Pkg.add("JuliaFormatter")
           using JuliaFormatter
           format(".", YASStyle())'
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         if: github.event_name == 'pull_request'
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| CompatHelper.yml | CompatHelper | none (default) | `contents: write`, `pull-requests: write` | CompatHelper pushes branches and opens PRs |
| TagBot.yml | TagBot | workflow-level explicit block | unchanged | Already explicitly scoped per TagBot docs |
| ci.yml | ci | none (default) | `contents: read` | Test-only job; no write access needed |
| documenter.yml | Documenter | `write-all` | `contents: write`, `statuses: write` | julia-docdeploy pushes gh-pages; Documenter posts commit status |
| spellcheck.yml | typos-check | none (default) | `contents: read`, `pull-requests: write` | reviewdog/action-suggester posts inline PR suggestions |
| style.yml | format-check | `write-all` | `contents: read`, `pull-requests: write` | reviewdog/action-suggester posts inline PR suggestions |
| zizmor.yaml | zizmor | n/a (new file) | `contents: read` | Read-only audit; no write access needed |
